### PR TITLE
Allow users to override more scheduler options

### DIFF
--- a/lib/dashing-contrib/runnable_job.rb
+++ b/lib/dashing-contrib/runnable_job.rb
@@ -37,12 +37,16 @@ module DashingContrib
     end
 
     def run(options = {}, &block)
-
       user_options = _merge_options(options)
       interval     = user_options.delete(:every)
+      scheduler_opts = user_options.delete(:scheduler) || {}
+
+      ## Keep this for compatibility.
+      #   Note: :first_in inside the :scheduler hash will override this.
       rufus_opt = {
         first_in: user_options[:first_in]
       }
+      rufus_opt.merge!(scheduler_opts)
 
       event_name   = user_options.delete(:event)
       block.call if block_given?


### PR DESCRIPTION
I would like to specify some other options like allow_overlapping and timeout.
Instead of adding more hardcoded values (cfr `first_in`) I added a config hash `scheduler`.

Since I don't see any prefab way to notify users with deprecation warnings, I omitted this and added a comment in code ;)