### PR TITLE
expose the switching javascript API via Dashing

### DIFF
--- a/lib/dashing-contrib/assets/widgets/switcher/switcher.coffee
+++ b/lib/dashing-contrib/assets/widgets/switcher/switcher.coffee
@@ -203,6 +203,11 @@ class DashboardSwitcherControls
     if @currentTime < 0
       @currentTime = 0
 
+# Expose our API
+Dashing.DashboardSwitcher = DashboardSwitcher
+Dashing.WidgetSwitcher = WidgetSwitcher
+Dashing.DashboardSwitcherControls = DashboardSwitcherControls
+
 # Dashboard loaded and ready
 Dashing.on 'ready', ->
   # If multiple widgets per list item, switch them periodically


### PR DESCRIPTION
This is to allow overriding the switching function so we can do things like fading.

For example, with the patch applied we can do the following to get fading when switching widgets, and also choose whether to enable switching in a grid or not.

```coffeescript
Dashing.WidgetSwitcher.prototype.start = (interval) ->
  interval = $(@elements.context).data 'switcher-interval'
  return if not interval > 0 # no switching if you didn't specify an interval

  @maxPos = @$elements.length
  @curPos = 1

  @$elements.slice(1).hide()

  @handle = setInterval =>
    count = @maxPos
    fadeIn = =>
      return if --count > 0
      $(@$elements[@curPos++]).fadeIn()
      @curPos %= @maxPos

    @$elements.fadeOut fadeIn # seems jQuery calls this for each element :-/

  , parseInt interval, 10
```