### PR TITLE
Fix uptime % for time ranges before check created

### DIFF
--- a/lib/dashing-contrib/bottles/pingdom/uptime.rb
+++ b/lib/dashing-contrib/bottles/pingdom/uptime.rb
@@ -8,7 +8,12 @@ module DashingContrib
       extend self
 
       def calc(credentials, id, from_time, to_time, rounding = 2)
-        payload = make_request(credentials, id, from_time, to_time)
+        checks  = ::DashingContrib::Pingdom::Checks.fetch(credentials, id)
+        used_from_time = from_time
+        if checks[:check][:created] > from_time
+          used_from_time = checks[:check][:created]
+        end
+        payload = make_request(credentials, id, used_from_time, to_time)
         summary = payload[:summary][:status]
         up     = summary[:totalup]
         unkown = summary[:totalunknown]

--- a/lib/dashing-contrib/bottles/pingdom/uptime.rb
+++ b/lib/dashing-contrib/bottles/pingdom/uptime.rb
@@ -8,10 +8,13 @@ module DashingContrib
       extend self
 
       def calc(credentials, id, from_time, to_time, rounding = 2)
+        # Find out when the check was created
         checks  = ::DashingContrib::Pingdom::Checks.fetch(credentials, id)
         used_from_time = from_time
-        if checks[:check][:created] > from_time
-          used_from_time = checks[:check][:created]
+        # if we're looking at time time range over the creation time, start from the creation time
+        if from_time <= checks[:check][:created] and checks[:check][:created] <= to_time
+          # use the creation time + 1 second (for initial check to settle)
+          used_from_time = checks[:check][:created] + 1
         end
         payload = make_request(credentials, id, used_from_time, to_time)
         summary = payload[:summary][:status]

--- a/lib/dashing-contrib/jobs/pingdom_uptime.rb
+++ b/lib/dashing-contrib/jobs/pingdom_uptime.rb
@@ -20,7 +20,7 @@ module DashingContrib
         second_uptime  = client.uptime(id, user_opt[:second_date_range], user_opt[:now])
         status   = client.checks(id)
 
-        if status[:check][:lasterrortime].nil ?
+        if status[:check][:lasterrortime].nil?
           last_down = "never"
         else
           last_down = ::DashingContrib::Time.readable_diff(::Time.at(status[:check][:lasterrortime]))


### PR DESCRIPTION
A final quick fix for today.... this adjusts the calculation of uptime to eliminate those negative numbers
it works by checking that the from_time < created_time < to_time and using the created_time if valid.
for ranges other ranges, the summary.average report should correctly show values, or unknown