### PR TITLE
New Widget : pingdom summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Now you will be able to use the following widgets, click to see individual docum
  * [Rickshawgraph](https://github.com/QubitProducts/dashing-contrib/wiki/Widget:-Rickshawgraph)
  * [Sidekiq](https://github.com/QubitProducts/dashing-contrib/wiki/Widget:-Sidekiq)
  * [Pingdom Uptime](https://github.com/QubitProducts/dashing-contrib/wiki/Widget:-Pingdom-Uptime)
+ * [Pingdom Summary](https://github.com/QubitProducts/dashing-contrib/wiki/Widget:-Pingdom-Summary)
  * [Kue Status](https://github.com/QubitProducts/dashing-contrib/wiki/Widget:-Kue-Status)
  * [Nagios List](https://github.com/QubitProducts/dashing-contrib/wiki/Widget:-Nagios-List)
  * [Switcher](https://github.com/QubitProducts/dashing-contrib/wiki/Widget:-Switcher)
@@ -127,6 +128,7 @@ Take a look some build-in jobs as example:
  * [dashing-contrib/jobs/kue.rb](https://github.com/QubitProducts/dashing-contrib/blob/master/lib/dashing-contrib/jobs/kue.rb)
  * [dashing-contrib/jobs/nagios_list.rb](https://github.com/QubitProducts/dashing-contrib/blob/master/lib/dashing-contrib/jobs/nagios_list.rb)
  * [dashing-contrib/jobs/pingdom_uptime.rb](https://github.com/QubitProducts/dashing-contrib/blob/master/lib/dashing-contrib/jobs/pingdom_uptime.rb)
+ * [dashing-contrib/jobs/pingdom_summary.rb](https://github.com/QubitProducts/dashing-contrib/blob/master/lib/dashing-contrib/jobs/pingdom_summary.rb)
  * [dashing-contrib/jobs/dashing-state.rb](https://github.com/QubitProducts/dashing-contrib/blob/master/lib/dashing-contrib/jobs/dashing-state.rb)
  
 This is nice that backend data fetching can be now unit tested and reused. Dashing widget view layer can reuse the same job processor and present data in multiple forms. 

--- a/lib/dashing-contrib/assets/widgets/pingdom_summary/pingdom_summary.coffee
+++ b/lib/dashing-contrib/assets/widgets/pingdom_summary/pingdom_summary.coffee
@@ -9,17 +9,9 @@ class Dashing.PingdomSummary extends Dashing.Widget
       when "ok"       then 'fa fa-smile-o'
       when "critical" then 'fa fa-frown-o'
       else                 'fa fa-meh-o'
-    #if (@get('status') == "ok") then 'fa fa-smile-o' else if (@get('status') == "warning") then 'fa fa-meh-o' else 'fa fa-frown-o'
-
-  @accessor 'siteState', ->
-    console.log("siteState called")
-    console.log(item)
-    if (@get('status') == "ok") then 'fa fa-smile-o' else if (@get('status') == "warning") then 'fa fa-meh-o' else 'fa fa-frown-o'
 
   @accessor 'statusClass', ->
     switch @get('status')
       when "ok"       then 'current-status-container status-up'
       when "critical" then 'current-status-container status-down'
       else                 'current-status-container status-unknown'
-      
-#    if (@get('status') == "ok") then 'current-status-container status-up' else if (@get('status') == "warning") then 'current-status-container status-meh' else 'current-status-container status-down'

--- a/lib/dashing-contrib/assets/widgets/pingdom_summary/pingdom_summary.coffee
+++ b/lib/dashing-contrib/assets/widgets/pingdom_summary/pingdom_summary.coffee
@@ -1,0 +1,25 @@
+class Dashing.PingdomSummary extends Dashing.Widget
+  @accessor 'up', Dashing.AnimatedValue
+  @accessor 'down', Dashing.AnimatedValue
+  @accessor 'unconfirmed_down', Dashing.AnimatedValue
+  @accessor 'unknown', Dashing.AnimatedValue
+  @accessor 'paused', Dashing.AnimatedValue
+  @accessor 'arrowClass', ->
+    switch @get('status')
+      when "ok"       then 'fa fa-smile-o'
+      when "critical" then 'fa fa-frown-o'
+      else                 'fa fa-meh-o'
+    #if (@get('status') == "ok") then 'fa fa-smile-o' else if (@get('status') == "warning") then 'fa fa-meh-o' else 'fa fa-frown-o'
+
+  @accessor 'siteState', ->
+    console.log("siteState called")
+    console.log(item)
+    if (@get('status') == "ok") then 'fa fa-smile-o' else if (@get('status') == "warning") then 'fa fa-meh-o' else 'fa fa-frown-o'
+
+  @accessor 'statusClass', ->
+    switch @get('status')
+      when "ok"       then 'current-status-container status-up'
+      when "critical" then 'current-status-container status-down'
+      else                 'current-status-container status-unknown'
+      
+#    if (@get('status') == "ok") then 'current-status-container status-up' else if (@get('status') == "warning") then 'current-status-container status-meh' else 'current-status-container status-down'

--- a/lib/dashing-contrib/assets/widgets/pingdom_summary/pingdom_summary.html
+++ b/lib/dashing-contrib/assets/widgets/pingdom_summary/pingdom_summary.html
@@ -1,0 +1,57 @@
+<div data-bind-class="state | prepend 'dashing-contrib state-'">
+    <section class="body">
+        <div class="canvas">
+
+            <div class="current-status-container" data-bind-class="statusClass">
+                <span data-bind="title"></span>
+                <span data-bind-class="arrowClass"></span>
+            </div>
+
+            <div class="row"> 
+                <div>
+                    <p class="left">Up:</p>
+                    <p class="figure right" data-bind="up | shortenedNumber | prepend prefix | append suffix"></p>
+                </div>
+            </div>
+
+            <div class="row"> 
+                <div>
+                    <p class="left top">Paused:</p>
+                    <p class="figure right top" data-bind="paused | shortenedNumber | prepend prefix | append suffix"></p>
+                </div>
+            </div>
+
+            <div class="row"> 
+                <div>
+                    <p class="left top">Unconfirmed:</p>
+                    <p class="figure right top" data-bind="unconfirmed_down | shortenedNumber | prepend prefix | append suffix"></p>
+                </div>
+            </div>
+
+            <div class="row"> 
+                    <p class="left top">Down:</p>
+                    <p class="figure right top" data-bind="down | shortenedNumber | prepend prefix | append suffix"></p>
+            </div>
+
+            <div class="row"> 
+                    <p class="left top">Unknown:</p>
+                    <p class="figure right top" data-bind="unknown | shortenedNumber | prepend prefix | append suffix"></p>
+            </div>
+
+            <div class="row"> 
+                    <p class="left doubletop">Total:</p>
+                    <p class="figure right doubletop" data-bind="total | shortenedNumber | prepend prefix | append suffix"></p>
+            </div>
+
+            <div class="row">
+               <ul class="list-nostyle">
+                 <li data-foreach-item="items">
+                    <span data-bind-class="item.state | prepend 'site-state-'">
+                    <span data-bind-class="item.state | prepend 'fa fa-' | append '-o' | replace 'ok', 'smile' | replace 'warning', 'meh' | replace 'critical','frown'" class="fa"></span></span>
+                    <span class="value" data-bind="item.label"></span>
+                 </li>
+               </ul>
+            </div>
+        </div>
+    </section>
+</div>

--- a/lib/dashing-contrib/assets/widgets/pingdom_summary/pingdom_summary.scss
+++ b/lib/dashing-contrib/assets/widgets/pingdom_summary/pingdom_summary.scss
@@ -81,28 +81,13 @@ $moreinfo-color:    rgba(255, 255, 255, 0.7);
     font-size: 10px;
   }
 
-  .more-info {
-    color: $moreinfo-color;
-    p {
-      font-size:12px;
-      color: #8b8b8b;
-    }
-    .figure {
-      font-size:18px;
-      color: #CECFCF;
-    }
-    &.past-status {
-      bottom: 80px;
-    }
+  .site-state-ok {
+    color: #9ACA3C;
   }
-
-    .site-state-ok {
-        color: #9ACA3C;
-    }
-    .site-state-warning {
-      color: #D9D31E;
-    }
-    .site-state-critical {
-      color: #C32026;
-    }
+  .site-state-warning {
+    color: #D9D31E;
+  }
+  .site-state-critical {
+    color: #C32026;
+  }
 }

--- a/lib/dashing-contrib/assets/widgets/pingdom_summary/pingdom_summary.scss
+++ b/lib/dashing-contrib/assets/widgets/pingdom_summary/pingdom_summary.scss
@@ -1,0 +1,108 @@
+// ----------------------------------------------------------------------------
+// Sass declarations
+// ----------------------------------------------------------------------------
+$background-color:  #2A2A2A;
+$value-color:       #73AA3A;
+
+$title-color:       #B2B2B2;
+$moreinfo-color:    rgba(255, 255, 255, 0.7);
+
+// ----------------------------------------------------------------------------
+// Widget styles
+// ----------------------------------------------------------------------------
+.widget-pingdom-summary {
+  //refreshing default widget definition
+  vertical-align: baseline !important;
+  padding:0px !important;
+
+  background-color: $background-color;
+
+  header{
+    background-color: #272727;
+    text-transform: uppercase;
+    padding: 5px 0px 5px 0px;
+    font-weight: 700;
+    font-size: 12px;
+    text-shadow: 1px 1px #0e0e0e;
+  }
+  .title {
+    color: $title-color;
+    font-size: inherit;
+  }
+
+  .body {
+    padding: 0px;
+    color: #d3d4d4;
+    text-shadow: 1px 1px #0e0e0e;
+    font-family: Helvetica, Arial, sans-serif;
+    z-index: 1;
+
+    .row {
+      width:100%;
+    }
+    .left {
+      float:left;
+      width:50%;
+    }
+    .right {
+      float:right;
+      width:49%;
+      border-left: 1px dotted #8b8b8b;
+    }
+    .top {
+      border-top: 1px dotted #8b8b8b;
+    }
+    .doubletop {
+      border-top: 2px dotted #8b8b8b;
+      border-bottom: 1px dotted #8b8b8b;
+    }
+  }
+
+  .current-status-container {
+    padding: 10px;
+    font-size: 30px;
+    text-shadow: none;
+    &.status-up {
+      color: #9ACA3C;
+    }
+    &.status-unknown {
+      color: #D9D31E;
+    }
+    &.status-down {
+      color: #C32026;
+    }
+
+    i.fa {
+      font-size: 55px;
+    }
+  }
+
+  .value {
+    font-size: 10px;
+  }
+
+  .more-info {
+    color: $moreinfo-color;
+    p {
+      font-size:12px;
+      color: #8b8b8b;
+    }
+    .figure {
+      font-size:18px;
+      color: #CECFCF;
+    }
+    &.past-status {
+      bottom: 80px;
+    }
+  }
+
+    .site-state-ok {
+        color: #9ACA3C;
+    }
+    .site-state-warning {
+      color: #D9D31E;
+    }
+    .site-state-critical {
+      color: #C32026;
+    }
+}

--- a/lib/dashing-contrib/bottles/pingdom/checks.rb
+++ b/lib/dashing-contrib/bottles/pingdom/checks.rb
@@ -10,9 +10,33 @@ module DashingContrib
         make_request(credentials, id)
       end
 
+      def summary(credentials)
+        checks = make_request(credentials, nil)
+        states = { 'up'               => { checks: { }, value: 0 },
+                   'down'             => { checks: { }, value: 0 },
+                   'unconfirmed_down' => { checks: { }, value: 0 },
+                   'unknown'          => { checks: { }, value: 0 },
+                   'paused'           => { checks: { }, value: 0 }
+                 }
+        #puts checks
+        checks[:checks].each { |check|
+          states[check[:status]] = { checks: states[check[:status]][:checks], value: (states[check[:status]][:value] + 1) }
+          if check.has_key?(:lasterrortime)
+            states[check[:status]][:checks][check[:lasterrortime]] = check[:name]
+          elsif check.has_key?(:lasttesttime)
+            states[check[:status]][:checks][check[:lasttesttime]] = check[:name]
+          end
+        }
+        return states
+      end
+
       private
       def make_request(credentials, id)
-        request_url = "https://#{credentials.username}:#{credentials.password}@api.pingdom.com/api/2.0/checks/#{id}"
+        if ( id.nil? )
+          request_url = "https://#{credentials.username}:#{credentials.password}@api.pingdom.com/api/2.0/checks/"
+        else
+          request_url = "https://#{credentials.username}:#{credentials.password}@api.pingdom.com/api/2.0/checks/#{id}"
+        end
         response = RestClient.get(request_url, { 'App-Key' => credentials.api_key })
         MultiJson.load response.body, { symbolize_keys: true }
       end

--- a/lib/dashing-contrib/bottles/pingdom/checks.rb
+++ b/lib/dashing-contrib/bottles/pingdom/checks.rb
@@ -18,7 +18,7 @@ module DashingContrib
                    'unknown'          => { checks: { }, value: 0 },
                    'paused'           => { checks: { }, value: 0 }
                  }
-        #puts checks
+
         checks[:checks].each { |check|
           states[check[:status]] = { checks: states[check[:status]][:checks], value: (states[check[:status]][:value] + 1) }
           if check.has_key?(:lasterrortime)

--- a/lib/dashing-contrib/bottles/pingdom/client.rb
+++ b/lib/dashing-contrib/bottles/pingdom/client.rb
@@ -18,6 +18,10 @@ module DashingContrib
       def uptime(id, from_time, to_time)
         ::DashingContrib::Pingdom::Uptime.calc(credentials, id, from_time, to_time)
       end
+
+      def summary()
+        ::DashingContrib::Pingdom::Checks.summary(credentials)
+      end
     end
   end
 end

--- a/lib/dashing-contrib/jobs/pingdom_summary.rb
+++ b/lib/dashing-contrib/jobs/pingdom_summary.rb
@@ -28,6 +28,12 @@ module DashingContrib
         tofind = options[:list_top] || 3
         list = Array.new
 
+ 	stateMap = { 'up' => 'ok',
+                     'paused' => 'ok',
+                     'unknown' => 'warning',
+                     'down' => 'critical',
+                     'unconfirmed_down' => 'critical' }
+
         repStates = ["down","unconfirmed_down","unknown","paused"]
         repStates.insert(-1, "up") if options[:include_up] || false
         repStates.each { |state| 
@@ -35,7 +41,7 @@ module DashingContrib
             touse =  status[state][:checks].keys.sort.take(tofind)
             tofind = tofind - touse.size
             touse.each { |key|
-              list.concat( [ { state: state, label: status[state][:checks][key] } ] )
+              list.concat( [ { state: stateMap[state], label: status[state][:checks][key] } ] )
             }
           end
         }

--- a/lib/dashing-contrib/jobs/pingdom_summary.rb
+++ b/lib/dashing-contrib/jobs/pingdom_summary.rb
@@ -1,0 +1,66 @@
+require 'dashing-contrib/bottles/pingdom'
+
+module DashingContrib
+  module Jobs
+    module PingdomSummary
+      extend DashingContrib::RunnableJob
+
+      def self.metrics(options)
+        client = DashingContrib::Pingdom::Client.new(
+          username: options[:username],
+          password: options[:password],
+          api_key:  options[:api_key]
+        )
+
+        status   = client.summary()
+        sum_status = 'ok'
+        sum_total = status["up"][:value] +
+                    status["paused"][:value] +
+                    status["unconfirmed_down"][:value] +
+                    status["down"][:value] +
+                    status["unknown"][:value] 
+        sum_ok = status["up"][:value] + status["paused"][:value]
+        sum_warn = status["unknown"][:value] + status["paused"][:value]
+        sum_crit = status["down"][:value] + status["unconfirmed_down"][:value]
+        sum_status = 'warning' if sum_warn > 0
+        sum_status = 'critical' if sum_crit > 0
+
+        tofind = options[:list_top] || 3
+        list = Array.new
+
+        repStates = ["down","unconfirmed_down","unknown","paused"]
+        repStates.insert(-1, "up") if options[:include_up] || false
+        repStates.each { |state| 
+          if tofind > 0
+            touse =  status[state][:checks].keys.sort.take(tofind)
+            tofind = tofind - touse.size
+            touse.each { |key|
+              list.concat( [ { state: state, label: status[state][:checks][key] } ] )
+            }
+          end
+        }
+
+        # returns this dataset
+        {
+          status: sum_status,
+          total: sum_total,
+          ok: sum_ok,
+          error: sum_crit,
+          up:  status["up"][:value],
+          down:  status["down"][:value],
+          unknown:  status["unknown"][:value],
+          paused:  status["paused"][:value],
+          unconfirmed_down:  status["unconfirmed_down"][:value],
+          items: list,
+        }
+      end
+
+      def self.validate_state(metrics, options = {})
+        return DashingContrib::RunnableJob::CRITICAL if metrics[:status] == 'critical'
+        return DashingContrib::RunnableJob::WARNING if metrics[:status] == 'warning'
+        DashingContrib::RunnableJob::OK
+      end
+
+    end
+  end
+end

--- a/lib/dashing-contrib/jobs/pingdom_summary.rb
+++ b/lib/dashing-contrib/jobs/pingdom_summary.rb
@@ -20,7 +20,7 @@ module DashingContrib
                     status["down"][:value] +
                     status["unknown"][:value] 
         sum_ok = status["up"][:value] + status["paused"][:value]
-        sum_warn = status["unknown"][:value] + status["paused"][:value]
+        sum_warn = status["unknown"][:value]
         sum_crit = status["down"][:value] + status["unconfirmed_down"][:value]
         sum_status = 'warning' if sum_warn > 0
         sum_status = 'critical' if sum_crit > 0
@@ -29,7 +29,7 @@ module DashingContrib
         list = Array.new
 
  	stateMap = { 'up' => 'ok',
-                     'paused' => 'ok',
+                     'paused' => 'warning',
                      'unknown' => 'warning',
                      'down' => 'critical',
                      'unconfirmed_down' => 'critical' }


### PR DESCRIPTION
Hi, 
   here's a compliment to the pingdom uptime widget - it displays a summary of all the pingdom checks, listing the number that are up, down, unknown, paused, etc, the total, and a list of the top 5 in a non-up/paused state

example job 
```ruby
require 'dashing-contrib/jobs/pingdom_summary'

DashingContrib::Jobs::PingdomSummary.run(
  every: '60s',
  event: 'pingdom-summary',
  username: ENV['PINGDOM_USERNAME'],
  password: ENV['PINGDOM_PASSWORD'],
  api_key:  ENV['PINGDOM_API_KEY'],
  list_top: 5,
  include_up: false,
)
```

example dashboard element
```html
    <li data-row='1' data-col='1' data-sizex='1' data-sizey='1'>
      <div data-id='pingdom-summary'
          data-title='Pingdom'
          data-view='PingdomSummary'></div>
    </li>
```