### PR TITLE
Add support for pingdom team accounts on summary and uptime

### DIFF
--- a/lib/dashing-contrib/bottles/pingdom/checks.rb
+++ b/lib/dashing-contrib/bottles/pingdom/checks.rb
@@ -37,7 +37,9 @@ module DashingContrib
         else
           request_url = "https://#{credentials.username}:#{credentials.password}@api.pingdom.com/api/2.0/checks/#{id}"
         end
-        response = RestClient.get(request_url, { 'App-Key' => credentials.api_key })
+        headers = { 'App-Key' => credentials.api_key }
+        headers['Account-Email'] = credentials.team_account unless credentials.team_account.empty?
+        response = RestClient.get(request_url, headers)
         MultiJson.load response.body, { symbolize_keys: true }
       end
     end

--- a/lib/dashing-contrib/bottles/pingdom/credentials.rb
+++ b/lib/dashing-contrib/bottles/pingdom/credentials.rb
@@ -3,13 +3,14 @@ require 'cgi'
 module DashingContrib
   module Pingdom
     class Credentials
-      attr_accessor :api_key, :username, :password
+      attr_accessor :api_key, :username, :password, :team_account
 
       def initialize(options = {})
         user_options = default_options.merge(options)
         @api_key = user_options[:api_key] || missing_args(:api_key)
         @password = CGI.escape(user_options[:password]) || missing_args(:password)
         @username = CGI.escape(user_options[:username]) || missing_args(:username)
+        @team_account = user_options[:team_account]
       end
 
       private
@@ -17,7 +18,8 @@ module DashingContrib
         {
             api_key: '',
             password: '',
-            username: ''
+            username: '',
+            team_account: ''
         }
       end
 

--- a/lib/dashing-contrib/bottles/pingdom/uptime.rb
+++ b/lib/dashing-contrib/bottles/pingdom/uptime.rb
@@ -29,7 +29,9 @@ module DashingContrib
       private
       def make_request(credentials, id, from_time, to_time)
         request_url = uptime_request_url(credentials, id, from_time, to_time)
-        response = RestClient.get(request_url, { 'App-Key' => credentials.api_key })
+        headers = { 'App-Key' => credentials.api_key }
+        headers['Account-Email'] = credentials.team_account unless credentials.team_account.empty?
+        response = RestClient.get(request_url, headers)
         MultiJson.load(response.body, { symbolize_keys: true })
       end
 

--- a/lib/dashing-contrib/jobs/pingdom_summary.rb
+++ b/lib/dashing-contrib/jobs/pingdom_summary.rb
@@ -9,7 +9,8 @@ module DashingContrib
         client = DashingContrib::Pingdom::Client.new(
           username: options[:username],
           password: options[:password],
-          api_key:  options[:api_key]
+          api_key:  options[:api_key],
+          team_account: options[:team_account]
         )
 
         status   = client.summary()

--- a/lib/dashing-contrib/jobs/pingdom_uptime.rb
+++ b/lib/dashing-contrib/jobs/pingdom_uptime.rb
@@ -9,7 +9,8 @@ module DashingContrib
         client = DashingContrib::Pingdom::Client.new(
           username: options[:username],
           password: options[:password],
-          api_key:  options[:api_key]
+          api_key:  options[:api_key],
+          team_account: options[:team_account]
         )
 
         user_opt = self.default_date_ranges.merge(options)


### PR DESCRIPTION
I've added an additional optional header for pingdom team accounts

By default it seems to use the account that is specified even though the Api key belongs to the team
account, the API specifies that for Multi-User https://www.pingdom.com/resources/api#multi-user+authentication, it should use an additional header for the main account