### PR TITLE
switch to 2nd widget after first interval

### DIFF
--- a/lib/dashing-contrib/assets/widgets/switcher/switcher.coffee
+++ b/lib/dashing-contrib/assets/widgets/switcher/switcher.coffee
@@ -80,7 +80,7 @@ class WidgetSwitcher
   start: (interval=5000) ->
     self = @
     @maxPos = @$elements.length - 1;
-    @curPos = 0
+    @curPos = Math.min(1, @maxPos)
 
     # Show only first at start
     self.$elements.slice(1).hide()


### PR DESCRIPTION
*Problem*

When using the widget switcher it displays the first element twice, then iterates over the rest consistently. To be able to synchronise different widgets with intervals of a multiple of each other, they become out of sync straight await.

*Solution*

Set the current Pos to 1 at the beginning, rather than 0. This will switch to 1 after the first interval.