### PR TITLE
Upgrade version lock on Sidekiq to 3.5.4

### DIFF
--- a/dashing-contrib.gemspec
+++ b/dashing-contrib.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'rest-client', '~> 1.6'
   spec.add_dependency 'multi_json', '~> 1.10'
   spec.add_dependency 'time_diff', '~> 0.3'
-  spec.add_dependency 'sidekiq', '~> 3.0'
+  spec.add_dependency 'sidekiq', '~> 0'
   spec.add_dependency 'activesupport', '~> 4.1'
   spec.add_dependency 'sinatra', '~> 1.4'
   spec.add_dependency 'dashing', '~> 1.3'

--- a/dashing-contrib.gemspec
+++ b/dashing-contrib.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'rest-client', '~> 1.6'
   spec.add_dependency 'multi_json', '~> 1.10'
   spec.add_dependency 'time_diff', '~> 0.3'
-  spec.add_dependency 'sidekiq', '~> 0'
+  spec.add_dependency 'sidekiq', '~> 3.5.4'
   spec.add_dependency 'activesupport', '~> 4.1'
   spec.add_dependency 'sinatra', '~> 1.4'
   spec.add_dependency 'dashing', '~> 1.3'

--- a/lib/dashing-contrib/version.rb
+++ b/lib/dashing-contrib/version.rb
@@ -1,3 +1,3 @@
 module DashingContrib
-  VERSION = '0.2.6'
+  VERSION = '0.2.7'
 end


### PR DESCRIPTION
Address version < 3.5.1 memory leak issue. #37 