### PR TITLE
Bump rest-client to 2.0.2

### DIFF
--- a/dashing-contrib.gemspec
+++ b/dashing-contrib.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   
   spec.add_dependency 'dotenv', '~> 0.11.1'
-  spec.add_dependency 'rest-client', '~> 1.6'
+  spec.add_dependency 'rest-client', '~> 2.0.2'
   spec.add_dependency 'multi_json', '~> 1.10'
   spec.add_dependency 'time_diff', '~> 0.3'
   spec.add_dependency 'sidekiq', '~> 3.5'


### PR DESCRIPTION
Bump `rest-client` to 2.0.2 as a project I'm working on fails trying to bring in dashing-contrib due to its older dependency on `rest-client`. Hoping to get this merged and a new release done if that's at all possible. Thanks AOT.